### PR TITLE
feat(header context): Add default header props to theme context

### DIFF
--- a/src/Components.js
+++ b/src/Components.js
@@ -70,16 +70,16 @@ export const BasicColHeader = styled.div`
   user-select: none;
   cursor: ${props => (props.sortable ? 'pointer' : 'default')};
   background-color: ${props => props.backgroundColor};
-  color: ${props => props.color || 'white'};
+  color: ${props => props.color};
   line-height: 1.3em;
-  font-weight: ${props => props.fontWeight || 'bold'};
-  font-size: ${props => props.fontSize || '0.85em'};
+  font-weight: ${props => props.fontWeight};
+  font-size: ${props => props.fontSize};
   padding-left: 0.5em;
   padding-right: 0.5em;
   padding-top: 0.3em;
   padding-bottom: 0.3em;
   &:first-child {
-    border-left: 1px solid steelblue;
+    border-left: 1px solid ${props => props.backgroundColor};
     border-top-left-radius: 3px;
   }
   &:last-child {

--- a/src/Components.js
+++ b/src/Components.js
@@ -69,7 +69,7 @@ export const BasicColHeader = styled.div`
   text-align: center;
   user-select: none;
   cursor: ${props => (props.sortable ? 'pointer' : 'default')};
-  background-color: ${props => props.backgroundColor || 'steelblue'};
+  background-color: ${props => props.backgroundColor};
   color: ${props => props.color || 'white'};
   line-height: 1.3em;
   font-weight: ${props => props.fontWeight || 'bold'};

--- a/src/context.js
+++ b/src/context.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 const options = {
   debug: false,
+  columnHeaderProps: { backgroundColor: "steelblue" }
 }
 
 const GridToolsContext = React.createContext(options)

--- a/src/context.js
+++ b/src/context.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 const options = {
   debug: false,
-  columnHeaderProps: { backgroundColor: "steelblue" }
+  columnHeaderProps: { color: 'white', backgroundColor: 'steelblue', fontWeight: 'bold', fontSize: '0.85em' }
 }
 
 const GridToolsContext = React.createContext(options)

--- a/src/flexRenderer.js
+++ b/src/flexRenderer.js
@@ -13,6 +13,7 @@ import {
   dropdownEditRender,
 } from './Components'
 import CellEditContainer from './CellEditContainer'
+import GridToolsContext from './context';
 // import { shallowEqualExplain } from 'shallow-equal-explain'
 
 export const ColHeader = BasicColHeader.extend`
@@ -179,27 +180,26 @@ class FlexGridCell extends React.PureComponent {
   }
 }
 
-export const defaultColHeaderRenderer = ({ header, sortOrder, width, ...rest }) => (
-  <ColHeader width={width} {...rest} sortable={header.sortable}>
-    {header.display}
-    {sortOrder === 'asc' ? (
-      <SortIndicator>&#x25b2;</SortIndicator>
-    ) : sortOrder === 'desc' ? (
-      <SortIndicator>&#x25bc;</SortIndicator>
-    ) : null}
-  </ColHeader>
-)
+export const defaultColHeaderRenderer = ({ header, sortOrder, width, ...rest }) => {
+  const gridContext = React.useContext(GridToolsContext);
+  return (
+    <ColHeader width={width} {...rest} {...gridContext.columnHeaderProps} sortable={header.sortable}>
+      {header.display}
+      {sortOrder === 'asc' ? (
+        <SortIndicator>&#x25b2;</SortIndicator>
+      ) : sortOrder === 'desc' ? (
+        <SortIndicator>&#x25bc;</SortIndicator>
+      ) : null}
+    </ColHeader>
+  )
+}
 
 // <SortIndicator className="fa fa-caret-up" aria-hidden="true" />
 // <SortIndicator className="fa fa-caret-down" aria-hidden="true" />
 
-class FlexGridColHeader extends React.PureComponent {
-  render() {
-    // console.log('scroll y is ', this.props.scrollY)
-    const { render = defaultColHeaderRenderer, ...rest } = this.props
-    return render(rest)
-  }
-}
+const FlexGridColHeader = ({ render = defaultColHeaderRenderer, ...rest }) => (
+  render(rest)
+)
 
 /* prettier-ignore */
 const FlexGridContainer = styled.div`

--- a/src/flexRenderer.js
+++ b/src/flexRenderer.js
@@ -197,9 +197,9 @@ export const defaultColHeaderRenderer = ({ header, sortOrder, width, ...rest }) 
 // <SortIndicator className="fa fa-caret-up" aria-hidden="true" />
 // <SortIndicator className="fa fa-caret-down" aria-hidden="true" />
 
-const FlexGridColHeader = ({ render = defaultColHeaderRenderer, ...rest }) => (
+const FlexGridColHeader = React.memo(({ render = defaultColHeaderRenderer, ...rest }) => (
   render(rest)
-)
+))
 
 /* prettier-ignore */
 const FlexGridContainer = styled.div`

--- a/src/stories/flex/flex.stories.js
+++ b/src/stories/flex/flex.stories.js
@@ -66,7 +66,7 @@ const OnEditCopyPasteDemo = () => {
     d.map(row => (row === originalRow ? editedRow : row))
 
   return (
-    <GridToolContext.Provider value={{ debug: true }}>
+    <GridToolContext.Provider value={{ debug: true, columnHeaderProps: { backgroundColor: "green" } }}>
       <Grid
         data={data}
         headers={debugHeaders}

--- a/src/stories/virtualized/virtualized.stories.js
+++ b/src/stories/virtualized/virtualized.stories.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 
-import Grid, { virtualizedGridRenderer } from '../../index'
+import Grid, { virtualizedGridRenderer, GridToolContext } from '../../index'
 
 import { createData, headers } from '../data'
 
@@ -10,13 +10,15 @@ const data = createData(80)
 storiesOf('Virtualized grid', module)
   .add('Basic', () => <Grid data={data} headers={headers} render={virtualizedGridRenderer()} />)
   .add('Fixed Col and Free edit', () => (
-    <Grid
-      isEditable={() => true}
-      editMode="cell"
-      data={data}
-      headers={headers}
-      altBgColor="red"
-      altBy={data => data.unitId}
-      render={virtualizedGridRenderer({ autoFixColByKey: true })}
-    />
+    <GridToolContext.Provider value={{ columnHeaderProps: { backgroundColor: "green" } }}>
+      <Grid
+        isEditable={() => true}
+        editMode="cell"
+        data={data}
+        headers={headers}
+        altBgColor="red"
+        altBy={data => data.unitId}
+        render={virtualizedGridRenderer({ autoFixColByKey: true })}
+      />
+    </GridToolContext.Provider>
   ))

--- a/src/virtualized/cellRender.js
+++ b/src/virtualized/cellRender.js
@@ -12,6 +12,7 @@ import { extractAndFormatData } from '../utils'
 import { Consumer } from './VirtualizedContext'
 /* justify-content: ${props => mapAlignmentToJustifyContent(props.alignment) || 'center'}; */
 import CellEditContainer from '../CellEditContainer'
+import GridToolsContext from '../context';
 
 export const Cell = BasicCell.extend`
   border-bottom: 1px solid #ccc;
@@ -24,16 +25,19 @@ const flattenCellProps = ({ style, ...props }) => ({ ...style, ...props })
 
 const OptimizedContentCell = pureComponent(Cell, flattenCellProps)
 
-const ColHeader = ({ header, sortOrder, width, ...rest }) => (
-  <ColHeaderBase width={width} {...rest} sortable={header.sortable}>
-    {header.display}
-    {sortOrder === 'asc' ? (
-      <SortIndicator>&#x25b2;</SortIndicator>
-    ) : sortOrder === 'desc' ? (
-      <SortIndicator>&#x25bc;</SortIndicator>
-    ) : null}
-  </ColHeaderBase>
-)
+const ColHeader = ({ header, sortOrder, width, ...rest }) => {
+  const gridContext = React.useContext(GridToolsContext);
+  return (
+    <ColHeaderBase width={width} {...rest} {...gridContext.columnHeaderProps} sortable={header.sortable}>
+      {header.display}
+      {sortOrder === 'asc' ? (
+        <SortIndicator>&#x25b2;</SortIndicator>
+      ) : sortOrder === 'desc' ? (
+        <SortIndicator>&#x25bc;</SortIndicator>
+      ) : null}
+    </ColHeaderBase>
+  )
+}
 
 export const cellRenderWrapper = (propPreProcessor = _ => _) => render => reactVirtualizedProps => (
   <Consumer key={reactVirtualizedProps.key}>

--- a/src/virtualized/virtualizedRenderer.js
+++ b/src/virtualized/virtualizedRenderer.js
@@ -5,6 +5,7 @@ import scrollbarSize from 'dom-helpers/util/scrollbarSize'
 import { Provider } from './VirtualizedContext'
 // import CellEditContainer from './CellEditContainer'
 import { defaultCellRender, cellRenderWrapper, defaultRowHeaderRender } from './cellRender'
+import GridToolsContext from "../context"
 
 const colWidthOf = cols => ({ index }) => cols[index].width
 
@@ -136,6 +137,7 @@ const VirtualizedRender = ({ renderOptions = {}, gridRenderProps }) => {
       columnHeaderGridRef.current.scrollToPosition({ scrollLeft: 0, scrollTop })
     }
   }, [])
+  const gridContext = React.useContext(GridToolsContext);
 
   return (
     <Provider value={gridRenderProps}>
@@ -239,7 +241,7 @@ const VirtualizedRender = ({ renderOptions = {}, gridRenderProps }) => {
               width: `${scrollbarSize() + (scrollX ? 0 : width - totalWidth)}px`,
               height: `${headerRowHeight}px`,
               top: '0px',
-              backgroundColor: 'steelblue',
+              backgroundColor: gridContext.columnHeaderProps.backgroundColor,
               borderRight: '1px solid #ccc',
               borderBottom: '1px solid #ccc',
               // borderLeft: '1px solid #ccc',


### PR DESCRIPTION
Context is added to control theme. Default background color will now be referred from context and can be overridden by supplying new context object at the time of using component.