### PR TITLE
fix(grid): clear selection on fuzzyFilter change

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -348,10 +348,9 @@ class Grid extends React.PureComponent {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(
         ({ editingRow, editingColumn, /* x1, x2, y1, y2, */ currentPage }) => ({
-          // x1: data !== nextProps.data ? undefined : x1,
-          // x2: data !== nextProps.data ? undefined : x2,
-          // y1: data !== nextProps.data ? undefined : y1,
-          // y2: data !== nextProps.data ? undefined : y2,
+          ...(fuzzyFilter !== nextProps.fuzzyFilter
+            ? { x1: undefined, x2: undefined, y1: undefined, y2: undefined }
+            : {}),
           ...this.generateViewProps({
             data: data !== nextProps.data ? nextProps.data : data,
             sortOptions: sortOptions !== nextProps.sortOptions ? nextProps.sortOptions : undefined,


### PR DESCRIPTION
we are using rectangle cordinate for selection, so when user apply fuzzy filter the actual data in
that selection rectangle is getting changed, so we need to clear selection on filter change to
preserve truthfullness of selected rows